### PR TITLE
Fix toggler visibility in dark mode

### DIFF
--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -96,6 +96,7 @@ const Toggler = styled.button`
   border: none;
   background: none;
   padding: 0;
+  color: var(--color-text);
 
   :focus,
   :active {


### PR DESCRIPTION
Before:
![Screenshot from 2020-10-10 00-01-45](https://user-images.githubusercontent.com/7492104/95644347-72a44700-0a8c-11eb-997b-4f7968f58e78.png)

After:
![Screenshot from 2020-10-10 00-05-19](https://user-images.githubusercontent.com/7492104/95644350-7932be80-0a8c-11eb-80e0-e99af9593f23.png)
